### PR TITLE
update dependencies to secure versions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["@babel/preset-flow", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-proposal-function-bind", "syntax-async-functions"],
+  "plugins": ["@babel/plugin-proposal-function-bind"],
   "ignore": [
     "src/assets/*"
   ]

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "vinyl-fs": "^3.0.3"
   },
   "devDependencies": {
-    "@babel/cli": "^7.4.4",
-    "@babel/core": "^7.4.5",
-    "@babel/plugin-proposal-function-bind": "^7.2.0",
-    "@babel/preset-env": "^7.4.5",
-    "@babel/preset-flow": "^7.0.0",
-    "@babel/preset-react": "^7.0.0",
+    "@babel/cli": "^7.11.5",
+    "@babel/core": "^7.11.5",
+    "@babel/plugin-proposal-function-bind": "^7.11.5",
+    "@babel/preset-env": "^7.11.5",
+    "@babel/preset-flow": "^7.10.4",
+    "@babel/preset-react": "^7.10.4",
     "babylon": "^6.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/developmentseed/documentationjs-devseed-theme#readme",
   "dependencies": {
     "concat-stream": "^1.6.0",
-    "documentation": "^5.2.2",
+    "documentation": "^13.0.2",
     "highlight.js": "^9.12.0",
     "lodash": "^4.17.4",
     "vinyl": "^2.1.0",


### PR DESCRIPTION
projects that depends by the current version of `documentation-devseed-theme` receives these warning
<img width="644" alt="image" src="https://user-images.githubusercontent.com/4289826/94990094-cf2dd080-0579-11eb-9ddf-f3ca709f1e64.png">

I've done some successful manual testing on local development environment `sw_vers Mac OS X 10.15.6 node --version v12.16.0` using `diff`  to compare the documentation site of a project of mine obtained before and after the change and I got identical output. 

Please note: to fix this security we need a more recent version of documentation.js but since building with these recent versions we got Error: Cannot find module 'babel-plugin-syntax-async-functions' from '/Users/ronda/projects/rondinif/documentation-devseed-theme'. it seems that with recent presets it is no longer necessary syntax-async-functions as a plugin in .babelrc so I removed it but I would like to be sure the maintainer pay attentions to these aspect and test it before approving the PR.

after the fix checking for vulnerabilities in `documentation-devseed-theme` should result in 
``` 
[documentation-devseed-theme (master)]$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 613 scanned packages
```